### PR TITLE
#109 feat/PassWordReset : 비밀번호 초기화 방식 이메일로 전송으로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 .vscode/
 
 .tmp.*
+
+src/main/resources/firebase/

--- a/src/main/java/com/campick/server/api/member/controller/PasswordResetController.java
+++ b/src/main/java/com/campick/server/api/member/controller/PasswordResetController.java
@@ -31,7 +31,7 @@ public class PasswordResetController {
     @Operation(summary = "비밀번호 재설정", description = "비밀번호 재설정")
     @PutMapping
     public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody ResetPasswordRequestDto request) {
-        passwordResetService.resetPasswordWithCode(request.getCode(), request.getNewPassword());
+        passwordResetService.resetPasswordWithCode(request.getCode());
         return ApiResponse.success_only(SuccessStatus.PASSWORD_RESET_SUCCESS);
     }
 }

--- a/src/main/java/com/campick/server/api/member/dto/ResetPasswordRequestDto.java
+++ b/src/main/java/com/campick/server/api/member/dto/ResetPasswordRequestDto.java
@@ -13,8 +13,8 @@ public class ResetPasswordRequestDto {
     @NotBlank(message = "인증 코드를 입력해주세요.")
     private String code;
 
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Size(min = 6, message = "비밀번호는 6자리 이상이어야 합니다.")
-    @Schema(example = "123456")
-    private String newPassword;
+//    @NotBlank(message = "비밀번호를 입력해주세요.")
+//    @Size(min = 6, message = "비밀번호는 6자리 이상이어야 합니다.")
+//    @Schema(example = "123456")
+//    private String newPassword;
 }

--- a/src/main/java/com/campick/server/api/member/service/MemberService.java
+++ b/src/main/java/com/campick/server/api/member/service/MemberService.java
@@ -66,9 +66,9 @@ public class MemberService {
             throw new BadRequestException(ErrorStatus.PASSWORD_MISMATCH_EXCEPTION.getMessage());
         }
 
-        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+//        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
-        Member member = requestDto.toEntity(encodedPassword);
+        Member member = requestDto.toEntity(requestDto.getPassword());
         memberRepository.save(member);
 
         if (requestDto.getRole() == Role.DEALER) {

--- a/src/main/java/com/campick/server/api/member/service/PasswordResetService.java
+++ b/src/main/java/com/campick/server/api/member/service/PasswordResetService.java
@@ -15,7 +15,11 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -26,6 +30,7 @@ public class PasswordResetService {
     private final PasswordResetRepository passwordResetRepository;
     private final JavaMailSender mailSender;
     private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
 
     @Value("cnckddn0146@gmail.com")
@@ -37,7 +42,7 @@ public class PasswordResetService {
         Member member = memberRepository.findByEmailAndIsDeletedFalse(email)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.EMAIL_NOT_FOUND.getMessage()));
 
-        String code = UUID.randomUUID().toString().replace("-", "");
+        String code = emailService.generateCode();
         LocalDateTime expiration = LocalDateTime.now().plusMinutes(15);
 
         PasswordReset reset = PasswordReset.builder()
@@ -59,7 +64,7 @@ public class PasswordResetService {
     }
 
     // 2. 인증코드 검증 및 비밀번호 재설정
-    public void resetPasswordWithCode(String code, String newPassword) {
+    public void resetPasswordWithCode(String code) {
         PasswordReset reset = passwordResetRepository.findByCode(code)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.PASSWORD_RESET_INVALID_CODE.getMessage()));
 
@@ -75,14 +80,54 @@ public class PasswordResetService {
         Member member = memberRepository.findByEmailAndIsDeletedFalse(reset.getEmail())
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage()));
 
-        if(member.getPassword().equals(newPassword)){
-            throw new BadRequestException(ErrorStatus.PASSWORD_RESET_INVALID_CODE.getMessage());
-        }
+        String newPassword = generateRandomPassword();
 
-        member.changePassword(passwordEncoder.encode(newPassword));
+//        member.updatePassword(passwordEncoder.encode(newPassword));
+        member.updatePassword(newPassword);
         memberRepository.save(member);
 
         reset.markVerified(); // 인증코드 사용 처리
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(String.format("캠픽 <%s>",serviceEmail));
+        message.setTo(member.getEmail());
+        message.setSubject("[Campick] 비밀번호 초기화 안내");
+        message.setText("비밀번호가 초기화 되었습니다 :\n\n" + newPassword);
+        mailSender.send(message);
         passwordResetRepository.save(reset);
+    }
+
+    private String generateRandomPassword() {
+        final String LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+        final String UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        final String NUMBERS = "0123456789";
+        final String SPECIAL = "!@#$%^&*()-_=+<>?";
+        final String ALL_CHARS = LOWERCASE + UPPERCASE + NUMBERS + SPECIAL;
+        final int PASSWORD_LENGTH = 7;
+
+        SecureRandom random = new SecureRandom();
+        List<Character> passwordChars = new ArrayList<>();
+
+        // 1. 각 종류의 문자를 하나씩 추가
+        passwordChars.add(LOWERCASE.charAt(random.nextInt(LOWERCASE.length())));
+        passwordChars.add(UPPERCASE.charAt(random.nextInt(UPPERCASE.length())));
+        passwordChars.add(NUMBERS.charAt(random.nextInt(NUMBERS.length())));
+        passwordChars.add(SPECIAL.charAt(random.nextInt(SPECIAL.length())));
+
+        // 2. 나머지 길이를 모든 문자 종류에서 랜덤하게 채움
+        for (int i = passwordChars.size(); i < PASSWORD_LENGTH; i++) {
+            passwordChars.add(ALL_CHARS.charAt(random.nextInt(ALL_CHARS.length())));
+        }
+
+        // 3. 예측 불가능하도록 리스트를 섞음
+        Collections.shuffle(passwordChars, random);
+
+        // 4. 최종 비밀번호 문자열 생성
+        StringBuilder password = new StringBuilder(PASSWORD_LENGTH);
+        for (Character ch : passwordChars) {
+            password.append(ch);
+        }
+
+        return password.toString();
     }
 }

--- a/src/main/java/com/campick/server/common/config/DataInitializer.java
+++ b/src/main/java/com/campick/server/common/config/DataInitializer.java
@@ -73,8 +73,8 @@ public class DataInitializer {
         }
 
         String rawPassword = "123456";
-        String encoded = passwordEncoder.encode(rawPassword);
-
+//        String encoded = passwordEncoder.encode(rawPassword);
+        String encoded = rawPassword;
         List<Member> members = new ArrayList<>();
 
         // 1) 4 ROLE_USER members


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #109 

## Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 비밀번호 초기화 방식 이메일로 전송으로 변경 하였습니다
- 그에 따라 모든 비밀번호가 현재 평문으로 저장됩니다

## Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
@vivivim 비밀번호가 평문으로 저장되네요

## Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
