### PR TITLE
#114 feat(UpdateMember): 멤버 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/campick/server/api/member/controller/MemberController.java
+++ b/src/main/java/com/campick/server/api/member/controller/MemberController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +25,7 @@ import java.util.Map;
 
 
 @RequestMapping("/api/member")
-@Tag(name="member", description = "멤버 관련 API 입니다.")
+@Tag(name = "member", description = "멤버 관련 API 입니다.")
 @RequiredArgsConstructor
 @RestController
 public class MemberController {
@@ -121,7 +120,7 @@ public class MemberController {
     @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"))
     @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(@Valid @RequestBody PasswordUpdateRequestDto requestDto,
-                                                            @AuthenticationPrincipal SecurityMember securityMember){
+                                                            @AuthenticationPrincipal SecurityMember securityMember) {
         memberService.updatePassword(
                 securityMember.getEmail(),
                 requestDto
@@ -129,8 +128,22 @@ public class MemberController {
         return ApiResponse.success_only(SuccessStatus.UPDATE_PASSWORD_SUCCESS);
     }
 
+    @Operation(summary = "회원 정보 수정 API", description = "현재 로그인된 사용자의 정보를 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "닉네임이 중복됩니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원을 찾을 수 없습니다.")
+    })
+    @PatchMapping("/update")
+    public ResponseEntity<ApiResponse<Void>> updateMemberInfo(
+            @AuthenticationPrincipal SecurityMember securityMember,
+            @RequestBody MemberUpdateRequestDto requestDto) {
+        memberService.updateMemberInfo(securityMember.getId(), requestDto);
+        return ApiResponse.success_only(SuccessStatus.UPDATE_MEMBER_INFO_SUCCESS);
+    }
+
     @Operation(summary = "프로필 이미지 변경 API", description = "사용자의 프로필 이미지를 변경합니다.")
-    @PutMapping(value = "/image", consumes = {"multipart/form-data"})
+    @PatchMapping(value = "/image", consumes = {"multipart/form-data"})
     public ResponseEntity<ApiResponse<ProfileImageUpdateResponseDto>> updateProfileImage(
             @RequestPart("file") MultipartFile file,
             @AuthenticationPrincipal SecurityMember securityMember
@@ -175,7 +188,7 @@ public class MemberController {
     @PostMapping("/check/password")
     public ResponseEntity<ApiResponse<Boolean>> checkPasswordValidation(@AuthenticationPrincipal SecurityMember securityMember,
                                                                         @RequestBody MemberPasswordCheckRequestDto requestDto) {
-        boolean isValidation = memberService.checkPasswordValidation(securityMember.getId(),requestDto.getPassword());
+        boolean isValidation = memberService.checkPasswordValidation(securityMember.getId(), requestDto.getPassword());
         return ApiResponse.success(SuccessStatus.CHECK_PASSWORD_VALIDATION, isValidation);
     }
 
@@ -198,9 +211,9 @@ public class MemberController {
     public ResponseEntity<ApiResponse<PageResponseDto<TransactionResponseDto>>> getMemberSold(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(defaultValue = "10") Integer size){
+            @RequestParam(defaultValue = "10") Integer size) {
         Pageable pageable = PageRequest.of(page, size);
-        PageResponseDto<TransactionResponseDto>  memberProductsIsAvailable = memberService.getMemberSold(memberId, pageable);
+        PageResponseDto<TransactionResponseDto> memberProductsIsAvailable = memberService.getMemberSold(memberId, pageable);
 
         return ApiResponse.success(SuccessStatus.SEND_MEMBER_SOLD_PRODUCTS_SUCCESS, memberProductsIsAvailable);
     }
@@ -211,7 +224,7 @@ public class MemberController {
     public ResponseEntity<ApiResponse<PageResponseDto<TransactionResponseDto>>> getMemberBought(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(defaultValue = "10") Integer size){
+            @RequestParam(defaultValue = "10") Integer size) {
         Pageable pageable = PageRequest.of(page, size);
         PageResponseDto<TransactionResponseDto> memberProductsIsAvailable = memberService.getMemberBought(memberId, pageable);
 
@@ -219,14 +232,12 @@ public class MemberController {
     }
 
 
-
-
     @Operation(summary = "{memberId}별 리뷰 조회", description = "{memberId}별 산 매물 기록을 봅니다")
     @GetMapping("/review/{memberId}")
     public ResponseEntity<ApiResponse<PageResponseDto<ReviewResponseDto>>> getMemberReview(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(defaultValue = "10") Integer size){
+            @RequestParam(defaultValue = "10") Integer size) {
         Pageable pageable = PageRequest.of(page, size);
         PageResponseDto<ReviewResponseDto> memberProductsIsAvailable = memberService.getReviewById(memberId, pageable);
 

--- a/src/main/java/com/campick/server/api/member/dto/MemberLoginResponseDto.java
+++ b/src/main/java/com/campick/server/api/member/dto/MemberLoginResponseDto.java
@@ -13,5 +13,6 @@ public class MemberLoginResponseDto {
     private String phoneNumber;
     private Long dealerId;
     private String role;
-
+    private String profileImageUrl;
+    private String profileThumbnailUrl;
 }

--- a/src/main/java/com/campick/server/api/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/com/campick/server/api/member/dto/MemberUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.campick.server.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateRequestDto {
+    private String nickname;
+    private String mobileNumber;
+    private String description;
+}

--- a/src/main/java/com/campick/server/api/member/entity/Member.java
+++ b/src/main/java/com/campick/server/api/member/entity/Member.java
@@ -74,6 +74,12 @@ public class Member extends BaseTimeEntity {
     //닉네임 변경
     public void updateNickname(String nickname) { this.nickname = nickname; }
 
+    // 핸드폰 번호 변경
+    public void updateMobileNumber(String mobileNumber) { this.mobileNumber = mobileNumber; }
+
+    // 소개 변경
+    public void updateDescription(String description) { this.description = description; }
+
     // 비밀번호 변경
     public void updatePassword(String password) { this.password = password; }
 

--- a/src/main/java/com/campick/server/api/member/service/MemberService.java
+++ b/src/main/java/com/campick/server/api/member/service/MemberService.java
@@ -9,7 +9,6 @@ import com.campick.server.api.member.entity.Member;
 import com.campick.server.api.member.entity.Role;
 import com.campick.server.api.member.repository.MemberRepository;
 import com.campick.server.api.product.entity.Product;
-import com.campick.server.api.product.entity.ProductStatus;
 import com.campick.server.api.product.repository.ProductRepository;
 import com.campick.server.api.review.entity.Review;
 import com.campick.server.api.review.repository.ReviewRepository;
@@ -25,15 +24,14 @@ import com.campick.server.common.storage.FirebaseStorageService;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -106,7 +104,6 @@ public class MemberService {
 
         String accessToken = jwtUtil.createJwt("access", member.getId(), member.getRole().name(), ACCESS_TOKEN_EXPIRATION_MS);
 
-
         redisTemplate.opsForValue().set(ACCESS_TOKEN_PREFIX + member.getId(), accessToken, ACCESS_TOKEN_EXPIRATION_MS, TimeUnit.MILLISECONDS);
 
         return MemberLoginResponseDto.builder()
@@ -116,6 +113,8 @@ public class MemberService {
                 .phoneNumber(member.getMobileNumber())
                 .dealerId(member.getDealer() != null ? member.getDealer().getId() : null)
                 .role(member.getRole().name())
+                .profileImageUrl(member.getProfileImageUrl())
+                .profileThumbnailUrl(member.getProfileThumbnailUrl())
                 .build();
     }
 
@@ -146,7 +145,6 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-
     public boolean isEmailDuplicate(String email) {
         return memberRepository.findByEmailAndIsDeletedFalse(email).isPresent();
     }
@@ -157,20 +155,17 @@ public class MemberService {
 
     @Transactional
     public void updatePassword(String email, @Valid PasswordUpdateRequestDto requestDto) {
-        if(!requestDto.getPassword().equals(requestDto.getConfirmPassword())){
+        if (!requestDto.getPassword().equals(requestDto.getConfirmPassword())) {
             throw new BadRequestException(ErrorStatus.PASSWORD_MISMATCH_EXCEPTION.getMessage());
         }
 
         Member targetMember = memberRepository.findByEmailAndIsDeletedFalse(email)
-                .orElseThrow(()-> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage()));
-
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage()));
 
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
         targetMember.updatePassword(encodedPassword);
         memberRepository.save(targetMember);
     }
-
-
 
     @Transactional
     public Map<String, String> updateProfileImage(String email, MultipartFile file) {
@@ -180,6 +175,41 @@ public class MemberService {
         member.updateProfileImage(imageUrls.get("profileImageUrl"), imageUrls.get("profileThumbnailUrl"));
         memberRepository.save(member);
         return imageUrls;
+    }
+
+    @Transactional
+    public void updateMemberInfo(Long memberId, MemberUpdateRequestDto requestDto) {
+        // 멤버가 있는지 확인
+        Member member = memberRepository.findByIdAndIsDeletedFalse(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage()));
+
+        // 닉네임이 중복인지 확인하는게 필요
+        String newNickname = requestDto.getNickname();
+        if (newNickname != null && !newNickname.isBlank() && !newNickname.equals(member.getNickname())) {
+            if (isNicknameDuplicate(newNickname)) {
+                throw new BadRequestException(ErrorStatus.DUPLICATE_NICKNAME_EXCEPTION.getMessage());
+            }
+            member.updateNickname(newNickname);
+        }else{
+            throw new BadRequestException(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
+        }
+
+        // 모바일 업데이트
+        String newMobileNumber = requestDto.getMobileNumber();
+        if (newMobileNumber != null && !newMobileNumber.isBlank()) {
+            member.updateMobileNumber(newMobileNumber);
+        } else{
+            throw new BadRequestException(ErrorStatus.VALIDATION_REQUEST_MISSING_EXCEPTION.getMessage());
+        }
+
+        // 자기소개 업데이트
+        // 자기소개는 빈칸이 가능함
+        String newDescription = requestDto.getDescription();
+        if (newDescription != null) {
+            member.updateDescription(newDescription);
+        }
+
+        memberRepository.save(member);
     }
 
     @Transactional
@@ -197,7 +227,7 @@ public class MemberService {
             id = jwtUtil.getId(token);
             role = jwtUtil.getRole(token);
         } catch (ExpiredJwtException e) {
-            // 메서드가 제대로 동작하지 ㅎ
+            // 메서드가 제대로 동작하지 않더라도 id와 role을 추출
             id = e.getClaims().get("id", Long.class);
             role = e.getClaims().get("role", String.class);
         }
@@ -222,9 +252,10 @@ public class MemberService {
                 .phoneNumber(member.getMobileNumber())
                 .dealerId(member.getDealer() != null ? member.getDealer().getId() : null)
                 .role(member.getRole().name())
+                .profileImageUrl(member.getProfileImageUrl())
+                .profileThumbnailUrl(member.getProfileThumbnailUrl())
                 .build();
     }
-
 
     public MemberResponseDto getMemberById(Long id) {
         Member member = memberRepository.findByIdAndIsDeletedFalse(id)
@@ -233,11 +264,9 @@ public class MemberService {
         return MemberResponseDto.of(member, reviews);
     }
 
-
     // N + 1 문제를 한번 스스로 생각해보기
     public PageResponseDto<ProductAvailableSummaryDto> getMemberProducts(Long id, Pageable pageable) {
-
-        if(memberRepository.findByIdAndIsDeletedFalse(id).isEmpty()) {
+        if (memberRepository.findByIdAndIsDeletedFalse(id).isEmpty()) {
             throw new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage());
         }
 
@@ -245,13 +274,12 @@ public class MemberService {
         // 하지만 여러번의 조인으로 인해서 N+1 문제가 발생해 성능 위기가 발생할 수 있다.
         // JPQL을 사용해서 FETCH JOIN으로 가능한 모든 ROW와 이와 연관된 테이블들의 정보 뷰를 만들어내어 N+1 문제를 제거
         Page<Product> products = productRepository.findProductByMemberIdWithDetails(id, pageable);
-        Page<ProductAvailableSummaryDto> productAvailableSummaryDtos = products.map(ProductAvailableSummaryDto::from);
         // 찾아왔으면 원하는 값에 알맞게 채워줌
         // 여러개의 products를 하나씩 보내면서 Dto를 만든다
         // 원래는 배열로 가능하나 Stream으로 편리하게 가능
+        Page<ProductAvailableSummaryDto> productAvailableSummaryDtos = products.map(ProductAvailableSummaryDto::from);
         return new PageResponseDto<>(productAvailableSummaryDtos);
     }
-
 
     // 내가 샀으니깐 판 사람의 id를 가지고 조회할게
     public PageResponseDto<TransactionResponseDto> getMemberBought(Long buyerId, Pageable pageable) {
@@ -263,12 +291,11 @@ public class MemberService {
         //! TODO N + 1은 추후에 풀어보기 ( 복습 )
         Page<Transaction> transactions = transactionRepository.findTransactionsByBuyer(buyer, pageable);
         Page<TransactionResponseDto> transactionDtos = transactions.map(transaction -> TransactionResponseDto.from(transaction, "SOLD"));
-
         return new PageResponseDto<>(transactionDtos);
     }
 
     // 내가 판
-    public PageResponseDto<TransactionResponseDto>  getMemberSold(Long sellerId, Pageable pageable) {
+    public PageResponseDto<TransactionResponseDto> getMemberSold(Long sellerId, Pageable pageable) {
         // 멤버가 존재하는지 확인
         Member seller = memberRepository.findById(sellerId).orElseThrow(
                 () -> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage())
@@ -276,7 +303,6 @@ public class MemberService {
 
         Page<Transaction> transactions = transactionRepository.findTransactionsBySeller(seller, pageable);
         Page<TransactionResponseDto> transactionDtos = transactions.map(transaction -> TransactionResponseDto.from(transaction, "BUY"));
-
         return new PageResponseDto<>(transactionDtos);
     }
 
@@ -288,17 +314,14 @@ public class MemberService {
 
         Page<Review> reviews = reviewRepository.findByTargetIdWithAuthor(memberId, pageable);
         Page<ReviewResponseDto> reviewResponseDtos = reviews.map(ReviewResponseDto::from);
-
         return new PageResponseDto<>(reviewResponseDtos);
     }
 
-
     public boolean checkPasswordValidation(Long memberId, String password) {
-         // 멤버가 존재하는지 확인
+        // 멤버가 존재하는지 확인
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage())
         );
-
         return member.getPassword().equals(password);
     }
 }

--- a/src/main/java/com/campick/server/common/response/ErrorStatus.java
+++ b/src/main/java/com/campick/server/common/response/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus {
     PASSWORD_RESET_CODE_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 비밀번호 재설정 코드입니다."),
     PASSWORD_RESET_ALREADY_USED(HttpStatus.BAD_REQUEST, "이전 비밀번호와 다른 비밀번호로 설정해주세요."),
     NOT_SELLER_EXCEPTION(HttpStatus.BAD_REQUEST, "이 매물의 판매자가 아닙니다"),
+    DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다. 다른 닉네임으로 시도해주세요."),
 
 
     /**

--- a/src/main/java/com/campick/server/common/response/SuccessStatus.java
+++ b/src/main/java/com/campick/server/common/response/SuccessStatus.java
@@ -28,11 +28,12 @@ public enum SuccessStatus {
     CHECK_NICKNAME_DUPLICATE(HttpStatus.OK, "닉네임 중복 검사 결과입니다."),
     CHECK_PASSWORD_VALIDATION(HttpStatus.OK, "비밀번호 확인 검사 결과입니다."),
     UPDATE_PASSWORD_SUCCESS(HttpStatus.OK, "비밀번호 변경 성공"),
-    UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경" ),
+    UPDATE_PROFILE_IMAGE_SUCCESS(HttpStatus.OK, "프로필 이미지 변경 성공" ),
     REISSUE_SUCCESS(HttpStatus.OK, "토큰 재발행 성공" ),
     SEND_FOLLOWING_LIST_SUCCESS(HttpStatus.OK, "회원 정보 조회 성공"),
     PASSWORD_RESET_LINK_SENT(HttpStatus.OK, "이메일 초기화 코드 전송 성공"),
-     PASSWORD_RESET_SUCCESS(HttpStatus.OK, "이메일 초기화 성공"),
+    PASSWORD_RESET_SUCCESS(HttpStatus.OK, "이메일 초기화 성공"),
+    UPDATE_MEMBER_INFO_SUCCESS(HttpStatus.OK, "멤버 정보 수정 성공"),
 
 
     WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴 성공"),


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #114 

## Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 로그인시에 이제 프로필 원본이미지와 프로필 썸네일이미지를 보내줍니다
- 멤버 정보 수정이 가능합니다
- 멤버 정보 수정시 닉네임 중복 검사를 합니다
- 멤버 정보 수정시 닉네임과 핸드폰 번호는 null이거나 빈칸일 수가 없습니다

## Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
