### PR TITLE
#196 회원 탈퇴시 회원이 올린 매물도 삭제

### DIFF
--- a/src/main/java/com/campick/server/api/member/service/MemberService.java
+++ b/src/main/java/com/campick/server/api/member/service/MemberService.java
@@ -139,10 +139,16 @@ public class MemberService {
 
     @Transactional
     public void deleteMember(Long memberId) {
+        // 멤버 지우기
         Member member = memberRepository.findByIdAndIsDeletedFalse(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.MEMBER_NOT_FOUND.getMessage()));
         member.delete();
         memberRepository.save(member);
+
+        // product is_deleted를 true로
+        List<Product> productsToDelete = productRepository.findProductsBySeller(member);
+        productsToDelete.forEach(product -> product.setIsDeleted(true));
+        productRepository.saveAll(productsToDelete);
     }
 
     public boolean isEmailDuplicate(String email) {


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #196 

## Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 회원 탈퇴 시에 해당 회원이 올린 매물 목록들도 Soft Delete 방식으로 삭제합니다.

## Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
@vivivim 만약에 필요하다면 채팅방에서도 해당 기능을 구현할 필요가 있을 것 같습니다

## Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
